### PR TITLE
Some users on RP server want to restore original round end timer.

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -1,7 +1,7 @@
 var/global/datum/controller/gameticker/ticker
 
 /datum/controller/gameticker
-	var/const/restart_timeout = 2 MINUTES //One minute is 600. /CITADEL CHANGE - reduces the round end restart timer to 2 minutes
+	var/const/restart_timeout = 3 MINUTES //One minute is 600.
 	var/current_state = GAME_STATE_PREGAME
 
 	var/hide_mode = 0


### PR DESCRIPTION
Did a poll on RP and it came around 5 to 0. This may be a vague example but feel free to consider this change.